### PR TITLE
Add Playlist Window Size Saving

### DIFF
--- a/spotifyamp.cpp
+++ b/spotifyamp.cpp
@@ -1522,7 +1522,6 @@ PlaylistWindow::PlaylistWindow(MainWindow *main_window) {
   id_ = 1;
   main_window_ = main_window;
   hover_button_ = -1;
-  Resize(WND_MAIN_W, WND_MAIN_H * 3);
 }
 
 PlaylistWindow::~PlaylistWindow() {
@@ -1531,6 +1530,7 @@ PlaylistWindow::~PlaylistWindow() {
 
 void PlaylistWindow::Load() {
   LoadPosition(main_window.screen_rect()->left, main_window.screen_rect()->bottom);
+  LoadSize(WND_MAIN_W, WND_MAIN_H * 3);
   SetCompact(PrefReadBool(false, "pl.compact"));
   font_size_ = PrefReadInt(10, "pl.font_size");
   row_height_ = 13;

--- a/window.cpp
+++ b/window.cpp
@@ -175,25 +175,40 @@ void PlatformWindowBase<PlatformWindow>::Create(PlatformWindow *owner_window) {
 
 
 template<>
-const char *PlatformWindowBase<PlatformWindow>::GetPositionKey(const char *side) {
-  static char leftKey[12]; 
-  snprintf(leftKey, sizeof(leftKey), "window_%d_%s", id_, side);
-  return leftKey;
+const char *PlatformWindowBase<PlatformWindow>::GetWindowKey(const char *key) {
+  static char windowKey[12]; 
+  snprintf(windowKey, sizeof(windowKey), "window_%d_%s", id_, key);
+  return windowKey;
 }
 
 
 template<>
 void PlatformWindowBase<PlatformWindow>::SavePosition() {
-  PrefWriteInt(screen_rect_.left, GetPositionKey("l"));
-  PrefWriteInt(screen_rect_.top, GetPositionKey("t"));
+  PrefWriteInt(screen_rect_.left, GetWindowKey("l"));
+  PrefWriteInt(screen_rect_.top, GetWindowKey("t"));
 }
 
 
 template<>
 void PlatformWindowBase<PlatformWindow>::LoadPosition(int def_left, int def_top) {
-  int left(PrefReadInt(def_left, GetPositionKey("l")));
-  int top(PrefReadInt(def_top, GetPositionKey("t")));
+  int left(PrefReadInt(def_left, GetWindowKey("l")));
+  int top(PrefReadInt(def_top, GetWindowKey("t")));
   Move(left, top);
+}
+
+
+template<>
+void PlatformWindowBase<PlatformWindow>::SaveSize() {
+  PrefWriteInt(width_, GetWindowKey("w"));
+  PrefWriteInt(height_, GetWindowKey("h"));
+}
+
+
+template<>
+void PlatformWindowBase<PlatformWindow>::LoadSize(int def_width, int def_height) {
+  int width(PrefReadInt(def_width, GetWindowKey("w")));
+  int height(PrefReadInt(def_height, GetWindowKey("h")));
+  Resize(width, height);
 }
 
 

--- a/window.h
+++ b/window.h
@@ -20,6 +20,9 @@ class PlatformWindowBase {
   void SavePosition();
   void LoadPosition(int def_left, int def_top);
 
+  void SaveSize();
+  void LoadSize(int def_width, int def_height);
+
   // Double all pixels
   void SetDoubleSize(bool v);
   bool double_size() const { return double_size_; }
@@ -64,7 +67,7 @@ class PlatformWindowBase {
   Rect screen_rect_;
   T *next_, *owner_;
  private:
-  const char *GetPositionKey(const char *side);
+  const char *GetWindowKey(const char *key);
 };
 
 #if defined(WITH_SDL)

--- a/window_sdl.cpp
+++ b/window_sdl.cpp
@@ -138,6 +138,8 @@ void PlatformWindow::MoveAllWindows() {
       SDL_SetWindowPosition(w->window_, r->left, r->top);
       SDL_SetWindowSize(w->window_, r->right - r->left, r->bottom - r->top);
       w->need_move_ = false;
+      w->SavePosition();
+      w->SaveSize();
     }
   }
 }

--- a/window_win32.cpp
+++ b/window_win32.cpp
@@ -249,6 +249,7 @@ void PlatformWindow::MoveAllWindows() {
                       r->right - r->left, r->bottom - r->top, SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_NOACTIVATE);
       w->need_move_ = false;
       w->SavePosition();
+      w->SaveSize();
     }
   }
   EndDeferWindowPos(dp);


### PR DESCRIPTION
# Description
This PR implements window size saving/loading, specifically for the Playlist window (as that is the only resizable window currently). @EthanMac1915 and I have tested the prelim release I made with this PR, r4-pre-3, all seems to be working well.

If anyone wants to test/use the code in this PR, download from https://github.com/DashTheDev/Spotiamp/releases/tag/r4-pre-3

# Note
Should this PR get merged and when you have time @kran27, could you please create a new release on the main repo? Last release is from June 30, 2023. Otherwise, people can just keep downloading from forked release I linked above.